### PR TITLE
set no-cache when building builder image

### DIFF
--- a/automation/jenkins_build.sh
+++ b/automation/jenkins_build.sh
@@ -17,7 +17,7 @@ done
 
 cd $DIR_NAME
 
-docker build -t node-$DIR_NAME-builder .
+docker build --no-cache=true -t node-$DIR_NAME-builder .
 
 for NODE_VERSION in $NODE_VERSIONS
 do


### PR DESCRIPTION
To avoid node builder image cached with old node repo